### PR TITLE
Add 'require' statement to README's usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Using this library you will see beautiful and various PNG artifacts.
 ## Usage
 
 ```ruby
+    require 'pnglitch'
+
     PNGlitch.open('/path/to/your/image.png') do |p|
       p.glitch do |data|
         data.gsub /\d/, 'x'


### PR DESCRIPTION
Hello!

Thanks for the great library.
This is just a change to the README that adds `require 'pnglitch'` to the usage example,
similar to the usage example currently in https://github.com/ucnv/aviglitch.

Thanks Again.