### PR TITLE
Proc.new with no block is obsolete from Ruby 3.0.0

### DIFF
--- a/lib/pnglitch.rb
+++ b/lib/pnglitch.rb
@@ -228,11 +228,10 @@ module PNGlitch
     #
     #   PNGlitch.open(infile, limit_of_decompressed_data_size: 1024 ** 3)
     #
-    def open file, options = {}
+    def open file, options = {}, &block
       base = Base.new file, options[:limit_of_decompressed_data_size]
       if block_given?
         begin
-          block = Proc.new
           if block.arity == 0
             base.instance_eval &block
           else

--- a/lib/pnglitch/scanline.rb
+++ b/lib/pnglitch/scanline.rb
@@ -11,7 +11,7 @@ module PNGlitch
     #
     # Instanciate.
     #
-    def initialize io, start_at, data_size, at
+    def initialize io, start_at, data_size, at, &block
       @index = at
       @io = io
       @start_at = start_at
@@ -27,7 +27,7 @@ module PNGlitch
       @filter_codec = { encoder: nil, decoder: nil }
 
       if block_given?
-        @callback = Proc.new
+        @callback = block
       end
     end
 


### PR DESCRIPTION
## summary

From Ruby 3.0.0, when Proc.new are called without a block, `ArgumentError` will sadly be raised.

Thanks for your great work. I really like your products.

## suggested changes

Use block argument `&block` instead of Proc.new

## related PR

- https://github.com/ruby/ruby/pull/3208